### PR TITLE
Simple fix for the path name to package conversion for windows

### DIFF
--- a/src/main/java/st/redline/classloader/SmalltalkSourceFile.java
+++ b/src/main/java/st/redline/classloader/SmalltalkSourceFile.java
@@ -172,7 +172,7 @@ public class SmalltalkSourceFile implements Source, LineTransformer {
             int index = packageName.lastIndexOf(File.separatorChar);
             if (index != -1)
                 packageName = packageName.substring(0, index);
-            packageName = packageName.replaceAll(String.valueOf(File.separatorChar), ".");
+            packageName = packageName.replace(File.separatorChar, '.');
         }
         return packageName;
     }


### PR DESCRIPTION
The `replaceAll` didn't like it when it received the backslash path separator on Windows.
Changed it to simply `replace` using characters.